### PR TITLE
make fizzbuzz_spec.rb consistent with lesson

### DIFF
--- a/spec/fizzbuzz_spec.rb
+++ b/spec/fizzbuzz_spec.rb
@@ -1,5 +1,4 @@
 require_relative './spec_helper.rb'
-require_relative '../fizzbuzz.rb'
 
 describe "fizzbuzz" do
   it 'returns "Fizz" when the number is divisible by 3' do


### PR DESCRIPTION
The flow of the lesson (specifically at the section titled "A Bit About Your Test Vs Your Program") relies on line 2 initially being absent from fizzbuzz_spec.rb.

Looks like part of the lesson solution was accidentally merged with the lesson material.